### PR TITLE
fix(observer): add support for Iframe Documents

### DIFF
--- a/src/BaseStyleSheetObserver.js
+++ b/src/BaseStyleSheetObserver.js
@@ -53,6 +53,10 @@ function isDocumentOrDocumentFragment(item) {
   if (typeof DocumentFragment === 'function' && item instanceof DocumentFragment) {
     return true;
   }
+  
+  if (item.defaultView && item.defaultView.HTMLDocument && item instanceof item.defaultView.HTMLDocument) {
+    return true;
+  }
 
   return false;
 }


### PR DESCRIPTION
the current checks only account for window owned Document objects but not iframes and thus the current code throws an error when working with iframes as `iframewindow.HTMLDocument !== window.HTMLDocument` 